### PR TITLE
Add an accessor to near and far clip planes to the Camera class

### DIFF
--- a/camera.h
+++ b/camera.h
@@ -85,6 +85,10 @@ public:
     return m_view_projection_matrix;
   }
 
+  float2 GetNearAndFarClip() const {
+    return float2{m_near_clip, m_far_clip};
+  }
+
 private:
   bool              m_pixel_aligned         = false;
   float3            m_eye                   = float3(0, 0, 1);


### PR DESCRIPTION
Like the title says. Helps build an app that uses depth linearisation in shaders, for instance.